### PR TITLE
Memoize the distances between points

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+yapf = "*"
 
 [packages]
 geopy = "*"
@@ -11,4 +12,4 @@ pycountry = "*"
 pycountry-convert = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+geopy = "*"
+pycountry = "*"
+pycountry-convert = "*"
+
+[requires]
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,185 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "0d87a422127216355939d6c9fd96876490d0aabfb758d91e4c6dae234dd122e8"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:15cf13a6896048d6d947bf7d222f36e4809ab926894beb748fc9caa14605d9c3",
+                "sha256:1daa3eceed220f9fdb80d5ff950dd95112cd27f70d004c7918ca6dfc6c47054c",
+                "sha256:1e44a022500d944d42f94df76727ba3fc0a5c0b672c358b61067abb88caee7a0",
+                "sha256:25dbf1110d70bab68a74b4b9d74f30e99b177cde3388e07cc7272f2168bd1477",
+                "sha256:3230d1003eec018ad4a472d254991e34241e0bbd513e97a29727c7c2f637bd2a",
+                "sha256:3dbb72eaeea5763676a1a1efd9b427a048c97c39ed92e13336e726117d0b72bf",
+                "sha256:5012d3b8d5a500834783689a5d2292fe06ec75dc86ee1ccdad04b6f5bf231691",
+                "sha256:51bc7710b13a2ae0c726f69756cf7ffd4362f4ac36546e243136187cfcc8aa73",
+                "sha256:527b4f316e6bf7755082a783726da20671a0cc388b786a64417780b90565b987",
+                "sha256:722e4557c8039aad9592c6a4213db75da08c2cd9945320220634f637251c3894",
+                "sha256:76e2057e8ffba5472fd28a3a010431fd9e928885ff480cb278877c6e9943cc2e",
+                "sha256:77afca04240c40450c331fa796b3eab6f1e15c5ecf8bf2b8bee9706cd5452fef",
+                "sha256:7afad9835e7a651d3551eab18cbc0fdb888f0a6136169fbef0662d9cdc9987cf",
+                "sha256:9bea19ac2f08672636350f203db89382121c9c2ade85d945953ef3c8cf9d2a68",
+                "sha256:a8b8ac7876bc3598e43e2603f772d2353d9931709345ad6c1149009fd1bc81b8",
+                "sha256:b0840b45187699affd4c6588286d429cd79a99d509fe3de0f209594669bb0954",
+                "sha256:b26aaf69713e5674efbde4d728fb7124e429c9466aeaf5f4a7e9e699b12c9fe2",
+                "sha256:b63dd43f455ba878e5e9f80ba4f748c0a2156dde6e0e6e690310e24d6e8caf40",
+                "sha256:be18f4ae5a9e46edae3f329de2191747966a34a3d93046dbdf897319923923bc",
+                "sha256:c312e57847db2526bc92b9bfa78266bfbaabac3fdcd751df4d062cd4c23e46dc",
+                "sha256:c60097190fe9dc2b329a0eb03393e2e0829156a589bd732e70794c0dd804258e",
+                "sha256:c62a2143e1313944bf4a5ab34fd3b4be15367a02e9478b0ce800cb510e3bbb9d",
+                "sha256:cc1109f54a14d940b8512ee9f1c3975c181bbb200306c6d8b87d93376538782f",
+                "sha256:cd60f507c125ac0ad83f05803063bed27e50fa903b9c2cfee3f8a6867ca600fc",
+                "sha256:d513cc3db248e566e07a0da99c230aca3556d9b09ed02f420664e2da97eac301",
+                "sha256:d649dc0bcace6fcdb446ae02b98798a856593b19b637c1b9af8edadf2b150bea",
+                "sha256:d7008a6796095a79544f4da1ee49418901961c97ca9e9d44904205ff7d6aa8cb",
+                "sha256:da93027835164b8223e8e5af2cf902a4c80ed93cb0909417234f4a9df3bcd9af",
+                "sha256:e69215621707119c6baf99bda014a45b999d37602cb7043d943c76a59b05bf52",
+                "sha256:ea9525e0fef2de9208250d6c5aeeee0138921057cd67fcef90fbed49c4d62d37",
+                "sha256:fca1669d464f0c9831fd10be2eef6b86f5ebd76c724d1e0706ebdff86bb4adf0"
+            ],
+            "version": "==5.0.3"
+        },
+        "geographiclib": {
+            "hashes": [
+                "sha256:12bd46ee7ec25b291ea139b17aa991e7ef373e21abd053949b75c0e9ca55c632",
+                "sha256:51cfa698e7183792bce27d8fb63ac8e83689cd8170a730bf35e1a5c5bf8849b9"
+            ],
+            "version": "==1.50"
+        },
+        "geopy": {
+            "hashes": [
+                "sha256:5de6fed0ee982e43a8e4243410477567cfccac22f8530edffc422761adf4e612",
+                "sha256:dc02b43ca5202696907b6b4f72431c8df455c812889dbb4e1240a672857f3adc"
+            ],
+            "index": "pypi",
+            "version": "==1.21.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+            ],
+            "version": "==8.2.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73",
+                "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"
+            ],
+            "version": "==20.1"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
+        "pprintpp": {
+            "hashes": [
+                "sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d",
+                "sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403"
+            ],
+            "version": "==0.4.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+            ],
+            "version": "==1.8.1"
+        },
+        "pycountry": {
+            "hashes": [
+                "sha256:3c57aa40adcf293d59bebaffbe60d8c39976fba78d846a018dc0c2ec9c6cb3cb"
+            ],
+            "index": "pypi",
+            "version": "==19.8.18"
+        },
+        "pycountry-convert": {
+            "hashes": [
+                "sha256:095d310f746bf2a5ef713b3a82eea28a27262286223765b1e7be8a5c4fa7e9b9",
+                "sha256:5e33883a88b3cb752d332ca2358ac6c4de4defc86a2b93b713b36338e914952e"
+            ],
+            "index": "pypi",
+            "version": "==0.7.2"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+            ],
+            "version": "==2.4.6"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
+                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
+            ],
+            "version": "==5.3.5"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
+                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+            ],
+            "version": "==2.8.1"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:b35eb281e93aafed138db25c8772b95d3756108b601947f89af503f8c629413f",
+                "sha256:cb67402d87d5f53c579263d37971a164743dc33c159dfb4fb4a86f37c5552307"
+            ],
+            "version": "==2.0.0"
+        },
+        "repoze.lru": {
+            "hashes": [
+                "sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77",
+                "sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea"
+            ],
+            "version": "==0.7"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
+                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
+            ],
+            "version": "==0.1.8"
+        },
+        "wheel": {
+            "hashes": [
+                "sha256:8788e9155fe14f54164c1b9eb0a319d98ef02c160725587ad60f14ddc57b6f96",
+                "sha256:df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e"
+            ],
+            "version": "==0.34.2"
+        }
+    },
+    "develop": {}
+}

--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,9 @@ More documentation to come.
 This project uses Python3. It relies on the `pycountry`, `pycontry-convert`, `request` and `geopy`
 libraries, all available through pip.
 
+If you have `pipenv` installed on your system, you can run `pipenv shell` to get a shell with the
+right dependencies installed locally to the directory.
+
 ############### Structure ###############
 
 ## input

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ More documentation to come.
 This project uses Python3. It relies on the `pycountry`, `pycontry-convert`, `request` and `geopy`
 libraries, all available through pip.
 
-If you have `pipenv` installed on your system, you can run `pipenv shell` to get a shell with the
+If you have `pipenv` installed on your system, you can run `pipenv shell` and then `pipenv sync` to get a shell with the
 right dependencies installed locally to the directory.
 
 ############### Structure ###############

--- a/input/generate_test_data.py
+++ b/input/generate_test_data.py
@@ -1,0 +1,35 @@
+
+
+def generate_people():
+    with open('participants.csv', 'w') as f:
+        print('headers...', file=f)
+        for i in range(1,500):
+            for y in range(9,18):
+                for conf in ['POPL', 'ICFP', 'PLDI', 'SPLASH']:
+                    if i % 3 == 0:
+                        loc = 'Paris,,France'
+                    elif i % 3 == 1:
+                        loc = 'Boston,MA,USA'
+                    else:
+                        loc = 'Tokyo,,Japan'
+                    print(f'{i}, {loc},{conf},{y}', file=f)
+
+
+def generate_confs():
+    with open('conferences.csv', 'w') as f:
+        print('headers...', file=f)
+        i = 0
+        for y in range(9,18):
+            for conf in ['POPL', 'ICFP', 'PLDI', 'SPLASH']:
+                i += 1
+                if i % 3 == 0:
+                    loc = 'Paris,,France'
+                elif i % 3 == 1:
+                    loc = 'Boston,MA,USA'
+                else:
+                    loc = 'Tokyo,,Japan'
+                print(f'{conf}, {y}, {loc}', file=f)
+
+
+generate_people()
+generate_confs()

--- a/src/datastructure.py
+++ b/src/datastructure.py
@@ -106,10 +106,17 @@ class Location:
             return self.GPS
 
     # Computes the distance between two locations
+
     def get_distance(self, GLOB, cache, start):
         c1 = start.get_and_set_GPS(GLOB, cache)
         c2 = self.get_and_set_GPS(GLOB, cache)
-        return distance.distance(c1,c2).km
+        if (c1, c2) in GLOB.memo_distances:
+            return GLOB.memo_distances[(c1,c2)]
+        else:
+            ret = distance.distance(c1,c2).km
+            GLOB.memo_distances[(c1,c2)] = ret
+            GLOB.memo_distances[(c2,c1)] = ret
+            return ret
 
     def set_iso(self,iso):
         self.country_iso = iso
@@ -255,7 +262,8 @@ class RawData:
         self.footprint = cost
 
     def get_cost_acm(self, GLOB, cache, destination):
-        logging.debug('Estimating acm cost (radiative forcing included) from {} to {}'.format(self.location,destination))
+        # commented out because it is quite costly cumulatively
+        #logging.debug('Estimating acm cost (radiative forcing included) from {} to {}'.format(self.location,destination))
         dist = self.location.get_distance(GLOB, cache, destination)
         if dist < 785:
             emission_factor = 0.14735

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -73,3 +73,5 @@ class Globals:
                                 ("Beijing",None,"China"),
                                 ("Mumbai",None,"India")]
 
+        self.memo_distances = {}
+


### PR DESCRIPTION
On my tests, the function `get_distance` takes 95% of the time because of all the trigonometric functions that are used, so we simply memoize them. On my simplistic test data, this reduces the running time from 1100s to 11s. Hopefully this strategy will also work well on the actual data.

Also add a Pipenv file to install automatically the dependencies, and a script to generate test data to test the program.