### PR TITLE
Add option of distinguishing between East and West (Fixes #3)

### DIFF
--- a/src/caching.py
+++ b/src/caching.py
@@ -48,7 +48,7 @@ class Cache:
         iso = loc.get_iso()
         loc.set_iso(iso)
         # print ("ISO done")
-        continent = loc.get_continent(iso)
+        continent = loc.get_continent(GLOB, iso, gps)
         loc.set_continent(continent)
         airport = loc.get_airport(GLOB, iso, gps)
         loc.set_airport(airport)
@@ -67,18 +67,19 @@ class Cache:
             # print("Location {} appears to be incorrect, giving up on it".format(loc))
 
     def check_cache_loc(self, GLOB, place):
-        if not place in self.cache:
-            try:
-                self.cache_new_loc(GLOB, place)
-            except e:
-                raise (e)
+        if place not in self.cache:
+            self.cache_new_loc(GLOB, place)
 
     def set_loc(self, GLOB, loc):
-        try:
-            cached_loc = self.cache[loc.place]
-            loc.set_GPS(cached_loc.GPS)
-            loc.set_iso(cached_loc.country_iso)
-            loc.set_continent(cached_loc.continent)
-            loc.set_airport(cached_loc.airport)
-        except e:
-            raise (e)
+        cached_loc = self.cache[loc.place]
+        loc.set_GPS(cached_loc.GPS)
+        loc.set_iso(cached_loc.country_iso)
+
+        continent = cached_loc.continent
+        if GLOB.east_west and continent == 'NA':
+            if cached_loc.GPS[1] > -100.0:
+                continent = 'EC'
+            else:
+                continent = 'WC'
+        loc.set_continent(continent)
+        loc.set_airport(cached_loc.airport)

--- a/src/datastructure.py
+++ b/src/datastructure.py
@@ -164,7 +164,7 @@ class Location:
     def set_continent(self, continent):
         self.continent = continent
 
-    def get_continent(self, iso):
+    def get_continent(self, GLOB, iso, gps):
         country = iso
         try:
             return country_alpha2_to_continent_code(country)

--- a/src/main.py
+++ b/src/main.py
@@ -57,10 +57,16 @@ def setup_args():
         help=
         'Assert that participants to events are not uniquely identified, disabling overlap analyses'
     )
+    parser.add_argument('--east-west-coast',
+                        action='store_true',
+                        help='Distinguish the east and the west coast in demographic analyses')
 
     args = parser.parse_args()
 
-    GLOB = Globals(args.input_events, args.input_participants, args.output_folder)
+    GLOB = Globals(args.input_events,
+                   args.input_participants,
+                   args.output_folder,
+                   east_west=args.east_west_coast)
 
     logging.info(
         "Analyzing the set of participants from file {} having taken part to events from file {}. The results of the analysis will be stored in folder {}."

--- a/src/parameters.py
+++ b/src/parameters.py
@@ -3,7 +3,7 @@
 
 
 class Globals:
-    def __init__(self, input_events, input_participants, output_folder):
+    def __init__(self, input_events, input_participants, output_folder, east_west=False):
 
         ## Nature of the fields of interest in the csv files intended to be read
         ## Used to guide the parser when building the internal data structures
@@ -62,6 +62,8 @@ class Globals:
         # Flag to set whether participants are uniquely identified, and hence if participation overlap can be computed
         self.unique_id = True
 
+        self.east_west = east_west
+
         ## List of names of the conferences to be considered when looking for a rough retroactive optimal
         self.city_candidates = [("Paris", None, "France"), ("Edinburgh", None, "UK"),
                                 ("Philadelphia", "PA", "USA"), ("Boston", "MA", "USA"),
@@ -70,3 +72,9 @@ class Globals:
                                 ("Mumbai", None, "India")]
 
         self.memo_distances = {}
+
+    def continents(self):
+        if self.east_west:
+            return ['EU', 'WC', 'EC', 'AS', 'SA', 'AF', 'OC']
+        else:
+            return ['EU', 'NA', 'AS', 'SA', 'AF', 'OC']


### PR DESCRIPTION
Using the option --east-west-coast. East is defined to start at -100
longitude.

Also clean up the demographic code a little using vector operations.

Fixes #3 